### PR TITLE
Fix six dependency

### DIFF
--- a/django_pgviews/view.py
+++ b/django_pgviews/view.py
@@ -10,7 +10,7 @@ from django.core import exceptions
 from django.db import connection, transaction
 from django.db.models.query import QuerySet
 from django.db import models
-from django.utils import six
+import six
 from django.apps import apps
 import psycopg2
 

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.20',
-    ]
+    ], install_requires=['six']
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
 psycopg2
-Django==2.2.2
+Django>=2.2.2


### PR DESCRIPTION
Django 2.2.9->2.2.10+ seems to have removed the six dependency for python2 and is only used two different places. This adds it back in for a quick fix.  

Closes #6 